### PR TITLE
Fix critical ItemDisplay errors (#33)

### DIFF
--- a/Assets/Scripts/Menus/Inventory/ItemDisplay.cs
+++ b/Assets/Scripts/Menus/Inventory/ItemDisplay.cs
@@ -45,7 +45,7 @@ public abstract class ItemDisplay : MonoBehaviour
 
     private void DestroySlots()
     {
-        for (int i = slots.Count - 1; i > 0; i--)
+        for (int i = slots.Count - 1; i > inventory.contents.Count - 1; i--)
         {
             var slot = slots[i];
             slots.Remove(slot);


### PR DESCRIPTION
Replace erroneous `0` with `inventory.contents.Count - 1` in `ItemDisplay.DestroySlots()`

Edit: Should address issue #33
[added issue link in message; see isaacs/github/issues/568]