### PR TITLE
Add support for a size limited Inventory

### DIFF
--- a/Assets/_Schwer/SchwerScripts/ItemSystem/Editor/InventoryDrawer.cs
+++ b/Assets/_Schwer/SchwerScripts/ItemSystem/Editor/InventoryDrawer.cs
@@ -17,7 +17,11 @@ namespace SchwerEditor.ItemSystem {
                 //! ^ Need to convert from `EditorGUILayout` to `EditorGUI`
             }
 
-            var foldoutRect = new Rect(position.x, position.y, position.width, EditorGUIUtility.singleLineHeight);
+            var capacityRect = new Rect(position.x, position.y, position.width, EditorGUIUtility.singleLineHeight);
+            EditorGUI.PropertyField(capacityRect, property.FindPropertyRelative("_maxCapacity"));
+            GUILayout.Space(EditorGUIUtility.singleLineHeight);
+
+            var foldoutRect = new Rect(position.x, position.y + EditorGUIUtility.singleLineHeight, position.width, EditorGUIUtility.singleLineHeight);
             property.isExpanded = EditorGUI.Foldout(foldoutRect, property.isExpanded, "Contents (" + keys.arraySize + ")", true);
 
             if (property.isExpanded) {
@@ -27,7 +31,7 @@ namespace SchwerEditor.ItemSystem {
                 var kvpSpacing = EditorGUIUtility.standardVerticalSpacing;
                 var halfWidth = position.width / 2;
                 for (int i = 0; i < keys.arraySize; i++) {
-                    var posY = position.y + ((i + 1) * (kvpHeight + kvpSpacing));
+                    var posY = position.y + EditorGUIUtility.singleLineHeight + ((i + 1) * (kvpHeight + kvpSpacing));
                     var keyRect = new Rect(position.x, posY, halfWidth, kvpHeight);
                     var valueRect = new Rect(position.x + halfWidth, posY, halfWidth, kvpHeight);
                     var key = keys.GetArrayElementAtIndex(i);

--- a/Assets/_Schwer/SchwerScripts/ItemSystem/Inventory.cs
+++ b/Assets/_Schwer/SchwerScripts/ItemSystem/Inventory.cs
@@ -15,6 +15,9 @@ namespace Schwer.ItemSystem {
         /// </remarks>
         public event Action<Item, int> OnContentsChanged;
 
+        [UnityEngine.SerializeField, UnityEngine.Min(1)] private int _maxCapacity = 21;
+        public int maxCapacity => _maxCapacity;
+
         // Reference for custom `Dictionary`-like behaviour:
         // https://stackoverflow.com/questions/6250706/override-dictionary-add
         private IDictionary<Item, int> backingDictionary;

--- a/Assets/_Schwer/SchwerScripts/ItemSystem/Inventory.cs
+++ b/Assets/_Schwer/SchwerScripts/ItemSystem/Inventory.cs
@@ -18,6 +18,8 @@ namespace Schwer.ItemSystem {
         [UnityEngine.SerializeField, UnityEngine.Min(1)] private int _maxCapacity = 21;
         public int maxCapacity => _maxCapacity;
 
+        public bool HasCapacity(Item item) => (this[item] > 0 || this.Count < maxCapacity);
+
         // Reference for custom `Dictionary`-like behaviour:
         // https://stackoverflow.com/questions/6250706/override-dictionary-add
         private IDictionary<Item, int> backingDictionary;


### PR DESCRIPTION
An elegant solution for ensuring that `Inventory.Count` is never > `Inventory.maxCapacity` may need to be implemented later. For now, use `HasCapacity()`.