### PR TITLE
Add new editor window for developer controls

### DIFF
--- a/Assets/_Schwer/Editor/DeveloperWindow.cs
+++ b/Assets/_Schwer/Editor/DeveloperWindow.cs
@@ -17,6 +17,7 @@ namespace SchwerEditor.Secrets
             EditorGUI.BeginDisabledGroup(!Application.isPlaying);
 
             FreezeTimeMiddayButton();
+            ResumeTimeButton();
 
             EditorGUI.EndDisabledGroup();
         }
@@ -30,7 +31,20 @@ namespace SchwerEditor.Secrets
                     Log("Time set to and frozen at midday.");
                 }
                 else {
-                    LogWarning("Could not find an active TimeManager");
+                    LogWarning("Could not find an active TimeManager!");
+                }
+            }
+        }
+
+        private void ResumeTimeButton() {
+            if (GUILayout.Button("Resume Time")) {
+                var time = FindObjectOfType<TimeManager>();
+                if (time != null) {
+                    SetPrivateField(time, "timeMultiplier", 1);
+                    Log("Time multiplier set to 1.");
+                }
+                else {
+                    LogWarning("Could not find an active TimeManager!");
                 }
             }
         }

--- a/Assets/_Schwer/Editor/DeveloperWindow.cs
+++ b/Assets/_Schwer/Editor/DeveloperWindow.cs
@@ -1,0 +1,48 @@
+﻿using UnityEditor;
+using UnityEngine;
+
+namespace SchwerEditor.Secrets
+{
+    public class DeveloperWindow : EditorWindow {
+        private const string _name = "Developer Controls";
+
+        [MenuItem("Window/" + _name)]
+        public static void ShowWindow() => GetWindow<DeveloperWindow>(_name);
+
+        private void OnGUI() {
+            if (!Application.isPlaying) {
+                EditorGUILayout.HelpBox("Enter Play Mode to enable developer controls.", MessageType.Info);
+            }
+
+            EditorGUI.BeginDisabledGroup(!Application.isPlaying);
+
+            FreezeTimeMiddayButton();
+
+            EditorGUI.EndDisabledGroup();
+        }
+
+        private void FreezeTimeMiddayButton() {
+            if (GUILayout.Button("Freeze Time Midday")) {
+                var time = FindObjectOfType<TimeManager>();
+                if (time != null) {
+                    SetPrivateField(time, "normalizedTimeOfDay", 0.5f);
+                    SetPrivateField(time, "timeMultiplier", 0);
+                    Log("Time set to and frozen at midday.");
+                }
+                else {
+                    LogWarning("Could not find an active TimeManager");
+                }
+            }
+        }
+
+        private static void Log(object message, Object context = null) => Debug.Log($"{_name}: {message}", context);
+        private static void LogWarning(object message, Object context = null) => Debug.LogWarning($"{_name}: {message}", context);
+        private static void LogError(object message, Object context = null) => Debug.LogError($"{_name}: {message}", context);
+
+        // Reference: https://stackoverflow.com/questions/12993962/set-value-of-private-field
+        private static void SetPrivateField(object instance, string fieldName, object value) {
+            var prop = instance.GetType().GetField(fieldName, System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
+            prop.SetValue(instance, value);
+        }
+    }
+}

--- a/Assets/_Schwer/Editor/DeveloperWindow.cs.meta
+++ b/Assets/_Schwer/Editor/DeveloperWindow.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: c23da49872f9ed54284de4397eb1de41
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Open from the menu bar (`Window/Developer Controls`).

Currently only has two controls:
- `Freeze Time Midday`
    - Finds an active `TimeManager` and sets its `normalizedTimeOfDay` to `0.5f` and `timeMultiplier` to `0`. 
- `Resume Time`
    - Finds an active `TimeManager` and sets its `timeMultiplier` to `1`.