### PR TITLE
Update VendorManager.cs

### DIFF
--- a/Assets/Scripts/Menus/Inventory/VendorManager.cs
+++ b/Assets/Scripts/Menus/Inventory/VendorManager.cs
@@ -58,7 +58,7 @@ public class VendorManager : ItemDisplay
     }
 
     private void ActivateInterface(Inventory vendorInventory) {
-        if (CanvasManager.Instance.IsFreeOrActive(vendorPanel))
+        if (CanvasManager.Instance.IsFreeOrActive(vendorPanel) && !vendorPanel.activeInHierarchy)
         {
             OpenInterface(vendorInventory);
             UpdateItemSlots();


### PR DESCRIPTION
Only activate the interface if it's not already active.

This prevents the issue where the vendor panel refreshes itself when "Interact" is input within range of a Vendor NPC.

Also see issue #50