### PR TITLE
Update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,3 +60,11 @@ crashlytics-build.properties
 
 # IntelliJ
 **/.idea/
+
+# Ignore folders made empty due to ignoring unitypackage files
+Assets/Plugins/Easy Save 3/Legacy
+Assets/Plugins/Easy Save 3/Legacy.meta
+Assets/Plugins/RainbowAssets/!Core/Source
+Assets/Plugins/RainbowAssets/!Core/Source.meta
+Assets/Plugins/RainbowAssets/RainbowFolders/Editor/Source
+Assets/Plugins/RainbowAssets/RainbowFolders/Editor/Source.meta

--- a/Assets/Plugins/Easy Save 3/Legacy.meta
+++ b/Assets/Plugins/Easy Save 3/Legacy.meta
@@ -1,8 +1,0 @@
-fileFormatVersion: 2
-guid: d05e819cd3894b045acde4e5ab56ebd4
-folderAsset: yes
-DefaultImporter:
-  externalObjects: {}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 

--- a/Assets/Plugins/Easy Save 3/Legacy/Easy Save 2.unitypackage.meta
+++ b/Assets/Plugins/Easy Save 3/Legacy/Easy Save 2.unitypackage.meta
@@ -1,7 +1,0 @@
-fileFormatVersion: 2
-guid: d731fabb47b47ae4a80c4d5cc24b57db
-DefaultImporter:
-  externalObjects: {}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 

--- a/Assets/Plugins/RainbowAssets/!Core/Source.meta
+++ b/Assets/Plugins/RainbowAssets/!Core/Source.meta
@@ -1,8 +1,0 @@
-fileFormatVersion: 2
-guid: c06cc0e20e07ea64faa9ca34c6295b6b
-folderAsset: yes
-DefaultImporter:
-  externalObjects: {}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 

--- a/Assets/Plugins/RainbowAssets/!Core/Source/RainbowCore.src.unitypackage.meta
+++ b/Assets/Plugins/RainbowAssets/!Core/Source/RainbowCore.src.unitypackage.meta
@@ -1,7 +1,0 @@
-fileFormatVersion: 2
-guid: 50ee1848c7a8ecc44932334370166827
-DefaultImporter:
-  externalObjects: {}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 

--- a/Assets/Plugins/RainbowAssets/RainbowFolders/Editor/Source.meta
+++ b/Assets/Plugins/RainbowAssets/RainbowFolders/Editor/Source.meta
@@ -1,8 +1,0 @@
-fileFormatVersion: 2
-guid: 0eb3ccdbfdef8e24a93975ee6fa94630
-folderAsset: yes
-DefaultImporter:
-  externalObjects: {}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 

--- a/Assets/Plugins/RainbowAssets/RainbowFolders/Editor/Source/RainbowFolders.src.unitypackage.meta
+++ b/Assets/Plugins/RainbowAssets/RainbowFolders/Editor/Source/RainbowFolders.src.unitypackage.meta
@@ -1,7 +1,0 @@
-fileFormatVersion: 2
-guid: 0248e41c3b61f024da11f0cfcc6f055d
-DefaultImporter:
-  externalObjects: {}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 


### PR DESCRIPTION
Update `.gitignore` to ignore folders made empty due to ignored `.unitypackage` files.

These folders are:
- `Assets/Plugins/Easy Save 3/Legacy`
- `Assets/Plugins/RainbowAssets/!Core/Source`
- `Assets/Plugins/RainbowAssets/RainbowFolders/Editor/Source`

As these are third-party asset folders, we shouldn't need be modifying files in these folders anyway, but it bears reminding that since these folders are no longer tracked, any changes in these folders will *not* be synchronised with others.