### PR TITLE
Save System Refactor: Inventory

### DIFF
--- a/Assets/ScriptableObjects/ItemDatabase.asset
+++ b/Assets/ScriptableObjects/ItemDatabase.asset
@@ -13,7 +13,7 @@ MonoBehaviour:
   m_Name: ItemDatabase
   m_EditorClassIdentifier: 
   items:
-  - {fileID: 11400000, guid: 95d051b96263cc147a8d7abff7a821ff, type: 2}
+  - {fileID: 11400000, guid: 982de6d362ecc9c48863f6e37c3984f2, type: 2}
   - {fileID: 11400000, guid: a48ff47b27b8b0c4ab2f418f70b976ad, type: 2}
   - {fileID: 11400000, guid: 75e4034ab1d762a4fb7a1e846d0b977f, type: 2}
   - {fileID: 11400000, guid: 7e9bc2e625f1fdf4f98d3866a2e45681, type: 2}
@@ -51,3 +51,15 @@ MonoBehaviour:
   - {fileID: 11400000, guid: 25d64f5e8266f794491efa4cc7ebd575, type: 2}
   - {fileID: 11400000, guid: 5aa21c7e4e5730f479f805410133a638, type: 2}
   - {fileID: 11400000, guid: 0d1957cc26114b249bfee7ebcad9f11e, type: 2}
+  - {fileID: 11400000, guid: 95d051b96263cc147a8d7abff7a821ff, type: 2}
+  - {fileID: 11400000, guid: 0d2797cb813ebf64dbff3a8f55796b4d, type: 2}
+  - {fileID: 11400000, guid: 5a0d13acc825aab409cbba18164c2c76, type: 2}
+  - {fileID: 11400000, guid: f605d951fdc861644875ebb3ea56f05d, type: 2}
+  - {fileID: 11400000, guid: b64669bd8bda2c645ac7f164efe16c8f, type: 2}
+  - {fileID: 11400000, guid: 448655c276888644f96d48aa0888e444, type: 2}
+  - {fileID: 11400000, guid: 7f8e34230cc326049b51abca7b4a78c6, type: 2}
+  - {fileID: 11400000, guid: a1bfbddc98cee354390573630aaf7158, type: 2}
+  - {fileID: 11400000, guid: ea6e9cea732cad647a48ee535ecb9a24, type: 2}
+  - {fileID: 11400000, guid: a43133d123662d344895354931d21d0b, type: 2}
+  - {fileID: 11400000, guid: c9203da9afc3c164a9d2d8153b334c0e, type: 2}
+  - {fileID: 11400000, guid: 718a499b2b0a745419b1491a631ed418, type: 2}

--- a/Assets/Scripts/GameManagers/SaveSystem/SimpleSave.cs
+++ b/Assets/Scripts/GameManagers/SaveSystem/SimpleSave.cs
@@ -91,6 +91,18 @@ public class SimpleSave : DDOLSingleton<SimpleSave>
         ES3.LoadInto("XP", loadSlot, so.xpSystem);
     }
 
+    private void SaveInventory(string key, Inventory inventory, string filePath)
+    {
+        var serializableInventory = new Inventory.SerializableInventory(inventory);
+        ES3.Save(key, serializableInventory, filePath);
+    }
+
+    private void LoadInventory(string key, string filePath, Inventory inventory, Schwer.ItemSystem.ItemDatabase itemDatabase)
+    {
+        var serializableInventory = ES3.Load(key, filePath) as Inventory.SerializableInventory;
+        serializableInventory.DeserializeInto(inventory, itemDatabase);
+    }
+
     private void SaveVendorInventories(string saveSlot)
     {
         //! TODO

--- a/Assets/Scripts/GameManagers/SaveSystem/SimpleSave.cs
+++ b/Assets/Scripts/GameManagers/SaveSystem/SimpleSave.cs
@@ -73,10 +73,9 @@ public class SimpleSave : DDOLSingleton<SimpleSave>
         ES3.Save("Health", so.health, saveSlot);
         ES3.Save("Mana", so.mana, saveSlot);
         ES3.Save("Lumen", so.lumen, saveSlot);
-
-        ES3.Save("Inventory", so.playerInventory, saveSlot);
-        ES3.Save("Items", so.playerInventory.items.Serialize(), saveSlot);
         ES3.Save("XP", so.xpSystem, saveSlot);
+
+        SaveInventory("Inventory", so.playerInventory, saveSlot);
     }
 
     private void LoadPlayer(string loadSlot)
@@ -85,10 +84,9 @@ public class SimpleSave : DDOLSingleton<SimpleSave>
         ES3.LoadInto("Health", loadSlot, so.health);
         ES3.LoadInto("Mana", loadSlot, so.mana);
         ES3.LoadInto("Lumen", loadSlot, so.lumen);
-
-        ES3.LoadInto("Inventory", loadSlot, so.playerInventory);
-        so.playerInventory.items = (ES3.Load("Items", loadSlot) as Schwer.ItemSystem.SerializableInventory).Deserialize(so.itemDatabase);
         ES3.LoadInto("XP", loadSlot, so.xpSystem);
+
+        LoadInventory("Inventory", loadSlot, so.playerInventory, so.itemDatabase);
     }
 
     private void SaveInventory(string key, Inventory inventory, string filePath)

--- a/Assets/Scripts/GameManagers/SaveSystem/SimpleSave.cs
+++ b/Assets/Scripts/GameManagers/SaveSystem/SimpleSave.cs
@@ -98,7 +98,7 @@ public class SimpleSave : DDOLSingleton<SimpleSave>
     private void LoadInventory(string key, string filePath, Inventory inventory, Schwer.ItemSystem.ItemDatabase itemDatabase)
     {
         var serializableInventory = ES3.Load(key, filePath) as Inventory.SerializableInventory;
-        serializableInventory.DeserializeInto(inventory, itemDatabase);
+        serializableInventory?.DeserializeInto(inventory, itemDatabase);
     }
 
     private void SaveVendorInventories(string saveSlot)

--- a/Assets/Scripts/ScriptableObjects/Inventory/Inventory.cs
+++ b/Assets/Scripts/ScriptableObjects/Inventory/Inventory.cs
@@ -332,6 +332,7 @@ public class Inventory : ScriptableObject
         private int? crownID = null;
         private int? scepterID = null;
 
+        public SerializableInventory() {}  // Parameterless constructor necessary to be compatible with ES3
         public SerializableInventory(Inventory inventory)
         {
             items = inventory.items.Serialize();

--- a/Assets/Scripts/ScriptableObjects/Inventory/Inventory.cs
+++ b/Assets/Scripts/ScriptableObjects/Inventory/Inventory.cs
@@ -304,33 +304,33 @@ public class Inventory : ScriptableObject
     [Serializable]
     public class SerializableInventory
     {
-        private Schwer.ItemSystem.SerializableInventory items;
+        [ES3Serializable] private Schwer.ItemSystem.SerializableInventory items;
 
-        private int? weaponID = null;
-        private int? armorID = null;
-        private int? helmetID = null;
-        private int? glovesID = null;
-        private int? legsID = null;
-        private int? shieldID = null;
-        private int? ringID = null;
-        private int? spellbook1ID = null;
-        private int? spellbook2ID = null;
-        private int? spellbook3ID = null;
-        private int? amuletID = null;
-        private int? bootsID = null;
-        private int? lampID = null;
-        private int? cloakID = null;
-        private int? shoulderID = null;
-        private int? sealID = null;
+        [ES3Serializable] private int? weaponID = null;
+        [ES3Serializable] private int? armorID = null;
+        [ES3Serializable] private int? helmetID = null;
+        [ES3Serializable] private int? glovesID = null;
+        [ES3Serializable] private int? legsID = null;
+        [ES3Serializable] private int? shieldID = null;
+        [ES3Serializable] private int? ringID = null;
+        [ES3Serializable] private int? spellbook1ID = null;
+        [ES3Serializable] private int? spellbook2ID = null;
+        [ES3Serializable] private int? spellbook3ID = null;
+        [ES3Serializable] private int? amuletID = null;
+        [ES3Serializable] private int? bootsID = null;
+        [ES3Serializable] private int? lampID = null;
+        [ES3Serializable] private int? cloakID = null;
+        [ES3Serializable] private int? shoulderID = null;
+        [ES3Serializable] private int? sealID = null;
 
-        private int? seedID = null;
-        private int? runeID = null;
-        private int? gemID = null;
-        private int? pearlID = null;
-        private int? eggID = null;
-        private int? artifactID = null;
-        private int? crownID = null;
-        private int? scepterID = null;
+        [ES3Serializable] private int? seedID = null;
+        [ES3Serializable] private int? runeID = null;
+        [ES3Serializable] private int? gemID = null;
+        [ES3Serializable] private int? pearlID = null;
+        [ES3Serializable] private int? eggID = null;
+        [ES3Serializable] private int? artifactID = null;
+        [ES3Serializable] private int? crownID = null;
+        [ES3Serializable] private int? scepterID = null;
 
         public SerializableInventory() {}  // Parameterless constructor necessary to be compatible with ES3
         public SerializableInventory(Inventory inventory)

--- a/Assets/Scripts/ScriptableObjects/Inventory/Inventory.cs
+++ b/Assets/Scripts/ScriptableObjects/Inventory/Inventory.cs
@@ -299,4 +299,100 @@ public class Inventory : ScriptableObject
             totalMaxSpellDamage += currentCloak.maxSpellDamage;
         }
     }
+
+    #region Serialisation
+    [Serializable]
+    public class SerializableInventory
+    {
+        private Schwer.ItemSystem.SerializableInventory items;
+
+        private int weaponID;
+        private int armorID;
+        private int helmetID;
+        private int glovesID;
+        private int legsID;
+        private int shieldID;
+        private int ringID;
+        private int spellbook1ID;
+        private int spellbook2ID;
+        private int spellbook3ID;
+        private int amuletID;
+        private int bootsID;
+        private int lampID;
+        private int cloakID;
+        private int shoulderID;
+        private int sealID;
+
+        private int seedID;
+        private int runeID;
+        private int gemID;
+        private int pearlID;
+        private int eggID;
+        private int artifactID;
+        private int crownID;
+        private int scepterID;
+
+        public SerializableInventory(Inventory inventory)
+        {
+            items = inventory.items.Serialize();
+
+            weaponID = inventory.currentWeapon.id;
+            armorID = inventory.currentArmor.id;
+            helmetID = inventory.currentHelmet.id;
+            glovesID = inventory.currentGloves.id;
+            legsID = inventory.currentLegs.id;
+            shieldID = inventory.currentShield.id;
+            ringID = inventory.currentRing.id;
+            spellbook1ID = inventory.currentSpellbook.id;
+            spellbook2ID = inventory.currentSpellbookTwo.id;
+            spellbook3ID = inventory.currentSpellbookThree.id;
+            amuletID = inventory.currentAmulet.id;
+            bootsID = inventory.currentBoots.id;
+            lampID = inventory.currentLamp.id;
+            cloakID = inventory.currentCloak.id;
+            shoulderID = inventory.currentShoulder.id;
+            sealID = inventory.currentSeal.id;
+
+            seedID = inventory.currentSeed.id;
+            runeID = inventory.currentRune.id;
+            gemID = inventory.currentGem.id;
+            pearlID = inventory.currentPearl.id;
+            eggID = inventory.currentDragonEgg.id;
+            artifactID = inventory.currentArtifact.id;
+            crownID = inventory.currentCrown.id;
+            scepterID = inventory.currentScepter.id;
+        }
+
+        public void DeserializeInto(Inventory target, Schwer.ItemSystem.ItemDatabase itemDatabase)
+        {
+            target.items = items.Deserialize(itemDatabase);
+
+            target.currentWeapon = (itemDatabase.GetItem(weaponID) as InventoryWeapon);
+            target.currentArmor = (itemDatabase.GetItem(armorID) as InventoryArmor);
+            target.currentHelmet = (itemDatabase.GetItem(helmetID) as InventoryHelmet);
+            target.currentGloves = (itemDatabase.GetItem(glovesID) as InventoryGlove);
+            target.currentLegs = (itemDatabase.GetItem(legsID) as InventoryLegs);
+            target.currentShield = (itemDatabase.GetItem(shieldID) as InventoryShield);
+            target.currentRing = (itemDatabase.GetItem(ringID) as InventoryRing);
+            target.currentSpellbook = (itemDatabase.GetItem(spellbook1ID) as InventorySpellbook);
+            target.currentSpellbookTwo = (itemDatabase.GetItem(spellbook2ID) as InventorySpellbook);
+            target.currentSpellbookThree = (itemDatabase.GetItem(spellbook3ID) as InventorySpellbook);
+            target.currentAmulet = (itemDatabase.GetItem(amuletID) as InventoryAmulet);
+            target.currentBoots = (itemDatabase.GetItem(bootsID) as InventoryBoots);
+            target.currentLamp = (itemDatabase.GetItem(lampID) as InventoryLamp);
+            target.currentCloak = (itemDatabase.GetItem(cloakID) as InventoryCloak);
+            target.currentShoulder = (itemDatabase.GetItem(shoulderID) as InventoryShoulder);
+            target.currentSeal = (itemDatabase.GetItem(sealID) as InventorySeal);
+
+            target.currentSeed = (itemDatabase.GetItem(seedID) as QuestSeed);
+            target.currentRune = (itemDatabase.GetItem(runeID) as QuestRune);
+            target.currentGem = (itemDatabase.GetItem(gemID) as QuestGem);
+            target.currentPearl = (itemDatabase.GetItem(pearlID) as QuestPearl);
+            target.currentDragonEgg = (itemDatabase.GetItem(eggID) as QuestDragonEgg);
+            target.currentArtifact = (itemDatabase.GetItem(artifactID) as QuestArtifact);
+            target.currentCrown = (itemDatabase.GetItem(crownID) as QuestCrown);
+            target.currentScepter = (itemDatabase.GetItem(scepterID) as QuestScepter);
+        }
+    }
+    #endregion
 }

--- a/Assets/Scripts/ScriptableObjects/Inventory/Inventory.cs
+++ b/Assets/Scripts/ScriptableObjects/Inventory/Inventory.cs
@@ -306,6 +306,8 @@ public class Inventory : ScriptableObject
     {
         [ES3Serializable] private Schwer.ItemSystem.SerializableInventory items;
 
+        [ES3Serializable] private int coins;
+
         [ES3Serializable] private int weaponID = int.MinValue;
         [ES3Serializable] private int armorID = int.MinValue;
         [ES3Serializable] private int helmetID = int.MinValue;
@@ -336,6 +338,7 @@ public class Inventory : ScriptableObject
         public SerializableInventory(Inventory inventory)
         {
             items = inventory.items.Serialize();
+            coins = inventory.coins;
 
             weaponID = GetIDOrMinValue(inventory.currentWeapon);
             armorID = GetIDOrMinValue(inventory.currentArmor);
@@ -367,6 +370,7 @@ public class Inventory : ScriptableObject
         public void DeserializeInto(Inventory target, Schwer.ItemSystem.ItemDatabase itemDatabase)
         {
             target.items = items.Deserialize(itemDatabase);
+            target.coins = coins;
 
             target.currentWeapon = (weaponID != int.MinValue ? itemDatabase.GetItem(weaponID) as InventoryWeapon : null);
             target.currentArmor = (armorID != int.MinValue ? itemDatabase.GetItem(armorID) as InventoryArmor : null);

--- a/Assets/Scripts/ScriptableObjects/Inventory/Inventory.cs
+++ b/Assets/Scripts/ScriptableObjects/Inventory/Inventory.cs
@@ -306,92 +306,92 @@ public class Inventory : ScriptableObject
     {
         private Schwer.ItemSystem.SerializableInventory items;
 
-        private int weaponID;
-        private int armorID;
-        private int helmetID;
-        private int glovesID;
-        private int legsID;
-        private int shieldID;
-        private int ringID;
-        private int spellbook1ID;
-        private int spellbook2ID;
-        private int spellbook3ID;
-        private int amuletID;
-        private int bootsID;
-        private int lampID;
-        private int cloakID;
-        private int shoulderID;
-        private int sealID;
+        private int? weaponID = null;
+        private int? armorID = null;
+        private int? helmetID = null;
+        private int? glovesID = null;
+        private int? legsID = null;
+        private int? shieldID = null;
+        private int? ringID = null;
+        private int? spellbook1ID = null;
+        private int? spellbook2ID = null;
+        private int? spellbook3ID = null;
+        private int? amuletID = null;
+        private int? bootsID = null;
+        private int? lampID = null;
+        private int? cloakID = null;
+        private int? shoulderID = null;
+        private int? sealID = null;
 
-        private int seedID;
-        private int runeID;
-        private int gemID;
-        private int pearlID;
-        private int eggID;
-        private int artifactID;
-        private int crownID;
-        private int scepterID;
+        private int? seedID = null;
+        private int? runeID = null;
+        private int? gemID = null;
+        private int? pearlID = null;
+        private int? eggID = null;
+        private int? artifactID = null;
+        private int? crownID = null;
+        private int? scepterID = null;
 
         public SerializableInventory(Inventory inventory)
         {
             items = inventory.items.Serialize();
 
-            weaponID = inventory.currentWeapon.id;
-            armorID = inventory.currentArmor.id;
-            helmetID = inventory.currentHelmet.id;
-            glovesID = inventory.currentGloves.id;
-            legsID = inventory.currentLegs.id;
-            shieldID = inventory.currentShield.id;
-            ringID = inventory.currentRing.id;
-            spellbook1ID = inventory.currentSpellbook.id;
-            spellbook2ID = inventory.currentSpellbookTwo.id;
-            spellbook3ID = inventory.currentSpellbookThree.id;
-            amuletID = inventory.currentAmulet.id;
-            bootsID = inventory.currentBoots.id;
-            lampID = inventory.currentLamp.id;
-            cloakID = inventory.currentCloak.id;
-            shoulderID = inventory.currentShoulder.id;
-            sealID = inventory.currentSeal.id;
+            weaponID = inventory.currentWeapon?.id;
+            armorID = inventory.currentArmor?.id;
+            helmetID = inventory.currentHelmet?.id;
+            glovesID = inventory.currentGloves?.id;
+            legsID = inventory.currentLegs?.id;
+            shieldID = inventory.currentShield?.id;
+            ringID = inventory.currentRing?.id;
+            spellbook1ID = inventory.currentSpellbook?.id;
+            spellbook2ID = inventory.currentSpellbookTwo?.id;
+            spellbook3ID = inventory.currentSpellbookThree?.id;
+            amuletID = inventory.currentAmulet?.id;
+            bootsID = inventory.currentBoots?.id;
+            lampID = inventory.currentLamp?.id;
+            cloakID = inventory.currentCloak?.id;
+            shoulderID = inventory.currentShoulder?.id;
+            sealID = inventory.currentSeal?.id;
 
-            seedID = inventory.currentSeed.id;
-            runeID = inventory.currentRune.id;
-            gemID = inventory.currentGem.id;
-            pearlID = inventory.currentPearl.id;
-            eggID = inventory.currentDragonEgg.id;
-            artifactID = inventory.currentArtifact.id;
-            crownID = inventory.currentCrown.id;
-            scepterID = inventory.currentScepter.id;
+            seedID = inventory.currentSeed?.id;
+            runeID = inventory.currentRune?.id;
+            gemID = inventory.currentGem?.id;
+            pearlID = inventory.currentPearl?.id;
+            eggID = inventory.currentDragonEgg?.id;
+            artifactID = inventory.currentArtifact?.id;
+            crownID = inventory.currentCrown?.id;
+            scepterID = inventory.currentScepter?.id;
         }
 
         public void DeserializeInto(Inventory target, Schwer.ItemSystem.ItemDatabase itemDatabase)
         {
             target.items = items.Deserialize(itemDatabase);
 
-            target.currentWeapon = (itemDatabase.GetItem(weaponID) as InventoryWeapon);
-            target.currentArmor = (itemDatabase.GetItem(armorID) as InventoryArmor);
-            target.currentHelmet = (itemDatabase.GetItem(helmetID) as InventoryHelmet);
-            target.currentGloves = (itemDatabase.GetItem(glovesID) as InventoryGlove);
-            target.currentLegs = (itemDatabase.GetItem(legsID) as InventoryLegs);
-            target.currentShield = (itemDatabase.GetItem(shieldID) as InventoryShield);
-            target.currentRing = (itemDatabase.GetItem(ringID) as InventoryRing);
-            target.currentSpellbook = (itemDatabase.GetItem(spellbook1ID) as InventorySpellbook);
-            target.currentSpellbookTwo = (itemDatabase.GetItem(spellbook2ID) as InventorySpellbook);
-            target.currentSpellbookThree = (itemDatabase.GetItem(spellbook3ID) as InventorySpellbook);
-            target.currentAmulet = (itemDatabase.GetItem(amuletID) as InventoryAmulet);
-            target.currentBoots = (itemDatabase.GetItem(bootsID) as InventoryBoots);
-            target.currentLamp = (itemDatabase.GetItem(lampID) as InventoryLamp);
-            target.currentCloak = (itemDatabase.GetItem(cloakID) as InventoryCloak);
-            target.currentShoulder = (itemDatabase.GetItem(shoulderID) as InventoryShoulder);
-            target.currentSeal = (itemDatabase.GetItem(sealID) as InventorySeal);
+            target.currentWeapon = (weaponID.HasValue ? itemDatabase.GetItem(weaponID.Value) as InventoryWeapon : null);
+            target.currentArmor = (armorID.HasValue ? itemDatabase.GetItem(armorID.Value) as InventoryArmor : null);
+            target.currentHelmet = (helmetID.HasValue ? itemDatabase.GetItem(helmetID.Value) as InventoryHelmet : null);
+            target.currentGloves = (glovesID.HasValue ? itemDatabase.GetItem(glovesID.Value) as InventoryGlove : null);
+            target.currentLegs = (legsID.HasValue ? itemDatabase.GetItem(legsID.Value) as InventoryLegs : null);
+            target.currentShield = (shieldID.HasValue ? itemDatabase.GetItem(shieldID.Value) as InventoryShield : null);
+            target.currentRing = (ringID.HasValue ? itemDatabase.GetItem(ringID.Value) as InventoryRing : null);
+            target.currentSpellbook = (spellbook1ID.HasValue ? itemDatabase.GetItem(spellbook1ID.Value) as InventorySpellbook : null);
+            target.currentSpellbookTwo = (spellbook2ID.HasValue ? itemDatabase.GetItem(spellbook2ID.Value) as InventorySpellbook : null);
+            target.currentSpellbookThree = (spellbook3ID.HasValue ? itemDatabase.GetItem(spellbook3ID.Value) as InventorySpellbook : null);
+            target.currentAmulet = (amuletID.HasValue ? itemDatabase.GetItem(amuletID.Value) as InventoryAmulet : null);
+            target.currentBoots = (bootsID.HasValue ? itemDatabase.GetItem(bootsID.Value) as InventoryBoots : null);
+            target.currentLamp = (lampID.HasValue ? itemDatabase.GetItem(lampID.Value) as InventoryLamp : null);
+            target.currentCloak = (cloakID.HasValue ? itemDatabase.GetItem(cloakID.Value) as InventoryCloak : null);
+            target.currentShoulder = (shoulderID.HasValue ? itemDatabase.GetItem(shoulderID.Value) as InventoryShoulder : null);
+            target.currentSeal = (sealID.HasValue ? itemDatabase.GetItem(sealID.Value) as InventorySeal : null);
 
-            target.currentSeed = (itemDatabase.GetItem(seedID) as QuestSeed);
-            target.currentRune = (itemDatabase.GetItem(runeID) as QuestRune);
-            target.currentGem = (itemDatabase.GetItem(gemID) as QuestGem);
-            target.currentPearl = (itemDatabase.GetItem(pearlID) as QuestPearl);
-            target.currentDragonEgg = (itemDatabase.GetItem(eggID) as QuestDragonEgg);
-            target.currentArtifact = (itemDatabase.GetItem(artifactID) as QuestArtifact);
-            target.currentCrown = (itemDatabase.GetItem(crownID) as QuestCrown);
-            target.currentScepter = (itemDatabase.GetItem(scepterID) as QuestScepter);
+            target.currentSeed = (seedID.HasValue ? itemDatabase.GetItem(seedID.Value) as QuestSeed : null);
+            target.currentRune = (runeID.HasValue ? itemDatabase.GetItem(runeID.Value) as QuestRune : null);
+            target.currentGem = (gemID.HasValue ? itemDatabase.GetItem(gemID.Value) as QuestGem : null);
+            target.currentPearl = (pearlID.HasValue ? itemDatabase.GetItem(pearlID.Value) as QuestPearl : null);
+            target.currentDragonEgg = (eggID.HasValue ? itemDatabase.GetItem(eggID.Value) as QuestDragonEgg : null);
+            target.currentArtifact = (artifactID.HasValue ? itemDatabase.GetItem(artifactID.Value) as QuestArtifact : null);
+            target.currentCrown = (crownID.HasValue ? itemDatabase.GetItem(crownID.Value) as QuestCrown : null);
+            target.currentScepter = (scepterID.HasValue ? itemDatabase.GetItem(scepterID.Value) as QuestScepter : null);
         }
     }
     #endregion

--- a/Assets/Scripts/ScriptableObjects/Inventory/Inventory.cs
+++ b/Assets/Scripts/ScriptableObjects/Inventory/Inventory.cs
@@ -18,7 +18,6 @@ public class Inventory : ScriptableObject
         }
     }
 
-
     public Item currentItem;
     [Header("Currently worn Items")]
     public InventoryWeapon currentWeapon;
@@ -54,10 +53,6 @@ public class Inventory : ScriptableObject
     public float totalCritChance;
     public int totalMinSpellDamage;
     public int totalMaxSpellDamage;
-
-
-
-
 
 #if UNITY_EDITOR
     // Needed in order to allow changes to the Inventory in the editor to be saved.
@@ -115,7 +110,6 @@ public class Inventory : ScriptableObject
                 Swap(ref currentRing, ring);
                  break;
 
-
             case InventorySpellbook spellbook:
                 if(!currentSpellbook)
                 {
@@ -130,8 +124,6 @@ public class Inventory : ScriptableObject
                     Swap(ref currentSpellbookThree, spellbook);
                 }
                 break;
-
-
 
             case InventoryAmulet amulet:
                 Swap(ref currentAmulet, amulet);
@@ -183,8 +175,6 @@ public class Inventory : ScriptableObject
         CalcDefense();
         CalcCritChance();
         CalcSpellDamage();
-
-
     }
 
     private void Swap<T>(ref T currentlyEquipped, T newEquip) where T : EquippableItem
@@ -310,4 +300,3 @@ public class Inventory : ScriptableObject
         }
     }
 }
-

--- a/Assets/Scripts/ScriptableObjects/Inventory/Inventory.cs
+++ b/Assets/Scripts/ScriptableObjects/Inventory/Inventory.cs
@@ -306,93 +306,99 @@ public class Inventory : ScriptableObject
     {
         [ES3Serializable] private Schwer.ItemSystem.SerializableInventory items;
 
-        [ES3Serializable] private int? weaponID = null;
-        [ES3Serializable] private int? armorID = null;
-        [ES3Serializable] private int? helmetID = null;
-        [ES3Serializable] private int? glovesID = null;
-        [ES3Serializable] private int? legsID = null;
-        [ES3Serializable] private int? shieldID = null;
-        [ES3Serializable] private int? ringID = null;
-        [ES3Serializable] private int? spellbook1ID = null;
-        [ES3Serializable] private int? spellbook2ID = null;
-        [ES3Serializable] private int? spellbook3ID = null;
-        [ES3Serializable] private int? amuletID = null;
-        [ES3Serializable] private int? bootsID = null;
-        [ES3Serializable] private int? lampID = null;
-        [ES3Serializable] private int? cloakID = null;
-        [ES3Serializable] private int? shoulderID = null;
-        [ES3Serializable] private int? sealID = null;
+        [ES3Serializable] private int weaponID = int.MinValue;
+        [ES3Serializable] private int armorID = int.MinValue;
+        [ES3Serializable] private int helmetID = int.MinValue;
+        [ES3Serializable] private int glovesID = int.MinValue;
+        [ES3Serializable] private int legsID = int.MinValue;
+        [ES3Serializable] private int shieldID = int.MinValue;
+        [ES3Serializable] private int ringID = int.MinValue;
+        [ES3Serializable] private int spellbook1ID = int.MinValue;
+        [ES3Serializable] private int spellbook2ID = int.MinValue;
+        [ES3Serializable] private int spellbook3ID = int.MinValue;
+        [ES3Serializable] private int amuletID = int.MinValue;
+        [ES3Serializable] private int bootsID = int.MinValue;
+        [ES3Serializable] private int lampID = int.MinValue;
+        [ES3Serializable] private int cloakID = int.MinValue;
+        [ES3Serializable] private int shoulderID = int.MinValue;
+        [ES3Serializable] private int sealID = int.MinValue;
 
-        [ES3Serializable] private int? seedID = null;
-        [ES3Serializable] private int? runeID = null;
-        [ES3Serializable] private int? gemID = null;
-        [ES3Serializable] private int? pearlID = null;
-        [ES3Serializable] private int? eggID = null;
-        [ES3Serializable] private int? artifactID = null;
-        [ES3Serializable] private int? crownID = null;
-        [ES3Serializable] private int? scepterID = null;
+        [ES3Serializable] private int seedID = int.MinValue;
+        [ES3Serializable] private int runeID = int.MinValue;
+        [ES3Serializable] private int gemID = int.MinValue;
+        [ES3Serializable] private int pearlID = int.MinValue;
+        [ES3Serializable] private int eggID = int.MinValue;
+        [ES3Serializable] private int artifactID = int.MinValue;
+        [ES3Serializable] private int crownID = int.MinValue;
+        [ES3Serializable] private int scepterID = int.MinValue;
 
         public SerializableInventory() {}  // Parameterless constructor necessary to be compatible with ES3
         public SerializableInventory(Inventory inventory)
         {
             items = inventory.items.Serialize();
 
-            weaponID = inventory.currentWeapon?.id;
-            armorID = inventory.currentArmor?.id;
-            helmetID = inventory.currentHelmet?.id;
-            glovesID = inventory.currentGloves?.id;
-            legsID = inventory.currentLegs?.id;
-            shieldID = inventory.currentShield?.id;
-            ringID = inventory.currentRing?.id;
-            spellbook1ID = inventory.currentSpellbook?.id;
-            spellbook2ID = inventory.currentSpellbookTwo?.id;
-            spellbook3ID = inventory.currentSpellbookThree?.id;
-            amuletID = inventory.currentAmulet?.id;
-            bootsID = inventory.currentBoots?.id;
-            lampID = inventory.currentLamp?.id;
-            cloakID = inventory.currentCloak?.id;
-            shoulderID = inventory.currentShoulder?.id;
-            sealID = inventory.currentSeal?.id;
+            weaponID = GetIDOrMinValue(inventory.currentWeapon);
+            armorID = GetIDOrMinValue(inventory.currentArmor);
+            helmetID = GetIDOrMinValue(inventory.currentHelmet);
+            glovesID = GetIDOrMinValue(inventory.currentGloves);
+            legsID = GetIDOrMinValue(inventory.currentLegs);
+            shieldID = GetIDOrMinValue(inventory.currentShield);
+            ringID = GetIDOrMinValue(inventory.currentRing);
+            spellbook1ID = GetIDOrMinValue(inventory.currentSpellbook);
+            spellbook2ID = GetIDOrMinValue(inventory.currentSpellbookTwo);
+            spellbook3ID = GetIDOrMinValue(inventory.currentSpellbookThree);
+            amuletID = GetIDOrMinValue(inventory.currentAmulet);
+            bootsID = GetIDOrMinValue(inventory.currentBoots);
+            lampID = GetIDOrMinValue(inventory.currentLamp);
+            cloakID = GetIDOrMinValue(inventory.currentCloak);
+            shoulderID = GetIDOrMinValue(inventory.currentShoulder);
+            sealID = GetIDOrMinValue(inventory.currentSeal);
 
-            seedID = inventory.currentSeed?.id;
-            runeID = inventory.currentRune?.id;
-            gemID = inventory.currentGem?.id;
-            pearlID = inventory.currentPearl?.id;
-            eggID = inventory.currentDragonEgg?.id;
-            artifactID = inventory.currentArtifact?.id;
-            crownID = inventory.currentCrown?.id;
-            scepterID = inventory.currentScepter?.id;
+            seedID = GetIDOrMinValue(inventory.currentSeed);
+            runeID = GetIDOrMinValue(inventory.currentRune);
+            gemID = GetIDOrMinValue(inventory.currentGem);
+            pearlID = GetIDOrMinValue(inventory.currentPearl);
+            eggID = GetIDOrMinValue(inventory.currentDragonEgg);
+            artifactID = GetIDOrMinValue(inventory.currentArtifact);
+            crownID = GetIDOrMinValue(inventory.currentCrown);
+            scepterID = GetIDOrMinValue(inventory.currentScepter);
         }
 
         public void DeserializeInto(Inventory target, Schwer.ItemSystem.ItemDatabase itemDatabase)
         {
             target.items = items.Deserialize(itemDatabase);
 
-            target.currentWeapon = (weaponID.HasValue ? itemDatabase.GetItem(weaponID.Value) as InventoryWeapon : null);
-            target.currentArmor = (armorID.HasValue ? itemDatabase.GetItem(armorID.Value) as InventoryArmor : null);
-            target.currentHelmet = (helmetID.HasValue ? itemDatabase.GetItem(helmetID.Value) as InventoryHelmet : null);
-            target.currentGloves = (glovesID.HasValue ? itemDatabase.GetItem(glovesID.Value) as InventoryGlove : null);
-            target.currentLegs = (legsID.HasValue ? itemDatabase.GetItem(legsID.Value) as InventoryLegs : null);
-            target.currentShield = (shieldID.HasValue ? itemDatabase.GetItem(shieldID.Value) as InventoryShield : null);
-            target.currentRing = (ringID.HasValue ? itemDatabase.GetItem(ringID.Value) as InventoryRing : null);
-            target.currentSpellbook = (spellbook1ID.HasValue ? itemDatabase.GetItem(spellbook1ID.Value) as InventorySpellbook : null);
-            target.currentSpellbookTwo = (spellbook2ID.HasValue ? itemDatabase.GetItem(spellbook2ID.Value) as InventorySpellbook : null);
-            target.currentSpellbookThree = (spellbook3ID.HasValue ? itemDatabase.GetItem(spellbook3ID.Value) as InventorySpellbook : null);
-            target.currentAmulet = (amuletID.HasValue ? itemDatabase.GetItem(amuletID.Value) as InventoryAmulet : null);
-            target.currentBoots = (bootsID.HasValue ? itemDatabase.GetItem(bootsID.Value) as InventoryBoots : null);
-            target.currentLamp = (lampID.HasValue ? itemDatabase.GetItem(lampID.Value) as InventoryLamp : null);
-            target.currentCloak = (cloakID.HasValue ? itemDatabase.GetItem(cloakID.Value) as InventoryCloak : null);
-            target.currentShoulder = (shoulderID.HasValue ? itemDatabase.GetItem(shoulderID.Value) as InventoryShoulder : null);
-            target.currentSeal = (sealID.HasValue ? itemDatabase.GetItem(sealID.Value) as InventorySeal : null);
+            target.currentWeapon = (weaponID != int.MinValue ? itemDatabase.GetItem(weaponID) as InventoryWeapon : null);
+            target.currentArmor = (armorID != int.MinValue ? itemDatabase.GetItem(armorID) as InventoryArmor : null);
+            target.currentHelmet = (helmetID != int.MinValue ? itemDatabase.GetItem(helmetID) as InventoryHelmet : null);
+            target.currentGloves = (glovesID != int.MinValue ? itemDatabase.GetItem(glovesID) as InventoryGlove : null);
+            target.currentLegs = (legsID != int.MinValue ? itemDatabase.GetItem(legsID) as InventoryLegs : null);
+            target.currentShield = (shieldID != int.MinValue ? itemDatabase.GetItem(shieldID) as InventoryShield : null);
+            target.currentRing = (ringID != int.MinValue ? itemDatabase.GetItem(ringID) as InventoryRing : null);
+            target.currentSpellbook = (spellbook1ID != int.MinValue ? itemDatabase.GetItem(spellbook1ID) as InventorySpellbook : null);
+            target.currentSpellbookTwo = (spellbook2ID != int.MinValue ? itemDatabase.GetItem(spellbook2ID) as InventorySpellbook : null);
+            target.currentSpellbookThree = (spellbook3ID != int.MinValue ? itemDatabase.GetItem(spellbook3ID) as InventorySpellbook : null);
+            target.currentAmulet = (amuletID != int.MinValue ? itemDatabase.GetItem(amuletID) as InventoryAmulet : null);
+            target.currentBoots = (bootsID != int.MinValue ? itemDatabase.GetItem(bootsID) as InventoryBoots : null);
+            target.currentLamp = (lampID != int.MinValue ? itemDatabase.GetItem(lampID) as InventoryLamp : null);
+            target.currentCloak = (cloakID != int.MinValue ? itemDatabase.GetItem(cloakID) as InventoryCloak : null);
+            target.currentShoulder = (shoulderID != int.MinValue ? itemDatabase.GetItem(shoulderID) as InventoryShoulder : null);
+            target.currentSeal = (sealID != int.MinValue ? itemDatabase.GetItem(sealID) as InventorySeal : null);
 
-            target.currentSeed = (seedID.HasValue ? itemDatabase.GetItem(seedID.Value) as QuestSeed : null);
-            target.currentRune = (runeID.HasValue ? itemDatabase.GetItem(runeID.Value) as QuestRune : null);
-            target.currentGem = (gemID.HasValue ? itemDatabase.GetItem(gemID.Value) as QuestGem : null);
-            target.currentPearl = (pearlID.HasValue ? itemDatabase.GetItem(pearlID.Value) as QuestPearl : null);
-            target.currentDragonEgg = (eggID.HasValue ? itemDatabase.GetItem(eggID.Value) as QuestDragonEgg : null);
-            target.currentArtifact = (artifactID.HasValue ? itemDatabase.GetItem(artifactID.Value) as QuestArtifact : null);
-            target.currentCrown = (crownID.HasValue ? itemDatabase.GetItem(crownID.Value) as QuestCrown : null);
-            target.currentScepter = (scepterID.HasValue ? itemDatabase.GetItem(scepterID.Value) as QuestScepter : null);
+            target.currentSeed = (seedID != int.MinValue ? itemDatabase.GetItem(seedID) as QuestSeed : null);
+            target.currentRune = (runeID != int.MinValue ? itemDatabase.GetItem(runeID) as QuestRune : null);
+            target.currentGem = (gemID != int.MinValue ? itemDatabase.GetItem(gemID) as QuestGem : null);
+            target.currentPearl = (pearlID != int.MinValue ? itemDatabase.GetItem(pearlID) as QuestPearl : null);
+            target.currentDragonEgg = (eggID != int.MinValue ? itemDatabase.GetItem(eggID) as QuestDragonEgg : null);
+            target.currentArtifact = (artifactID != int.MinValue ? itemDatabase.GetItem(artifactID) as QuestArtifact : null);
+            target.currentCrown = (crownID != int.MinValue ? itemDatabase.GetItem(crownID) as QuestCrown : null);
+            target.currentScepter = (scepterID != int.MinValue ? itemDatabase.GetItem(scepterID) as QuestScepter : null);
+        }
+
+        private int GetIDOrMinValue(Item item)
+        {
+            if (item != null) return item.id;
+            else return int.MinValue;
         }
     }
     #endregion


### PR DESCRIPTION
Refactor logic to save the ids of equipped items rather than trying to save whole `ScriptableObject`s.

Implemented using a new class, `SerializableInventory`, the serializable form of `Inventory`.

Fixes issue #66.