### PR TITLE
Ensure Inventory deserialization is thread-safe and fix ItemEditor GUI error

### DIFF
--- a/Assets/_Schwer/SchwerScripts/ItemSystem/Editor/ItemEditor.cs
+++ b/Assets/_Schwer/SchwerScripts/ItemSystem/Editor/ItemEditor.cs
@@ -49,14 +49,15 @@ namespace SchwerEditor.ItemSystem {
         // OnGUI is supposedly called many times per (render) frame (crude debug logging indicates this *is* the case),
         // so use Update for non-render logic.
         // Also see this: https://stackoverflow.com/questions/56298821/balancing-calls-inside-of-a-editorwindow-ongui-method-causing-problems
-        private void Update() {
-            //! Should probably only run this line if an Item asset was created or deleted.
-            itemAssets = AssetsUtility.FindAllAssets<Item>().OrderBy(i => i.id).ToArray();
-
-            Repaint();
-        }
+        private void Update() => Repaint();
 
         private void OnGUI() {
+            // Only change what should be drawn (for the next frame?) during `Layout` event.
+            if (Event.current.rawType == EventType.Layout) {
+                //! Should probably only run this line if an Item asset was created or deleted.
+                itemAssets = AssetsUtility.FindAllAssets<Item>().OrderBy(i => i.id).ToArray();
+            }
+
             EditorGUILayout.BeginHorizontal();
             selectedItem = DrawItemsSidebar(itemAssets);
             DrawSelectedItem();

--- a/Assets/_Schwer/SchwerScripts/ItemSystem/Inventory.cs
+++ b/Assets/_Schwer/SchwerScripts/ItemSystem/Inventory.cs
@@ -145,7 +145,9 @@ namespace Schwer.ItemSystem {
         }
 
         private void ListsToDictionary() {
-            this.Clear();
+            backingDictionary.Clear();
+            // Must not invoke `OnContentsChanged` to avoid UnityExceptions (no Unity Scripting API access in serialization thread!)
+            // Refer to: https://docs.unity3d.com/Manual/script-Serialization-Errors.html
 
             if(keys.Count != values.Count) {
                 throw new Exception($"Deserialization failed: The number of keys ({keys.Count}) and values ({values.Count}) are not equal.");


### PR DESCRIPTION
## `Inventory` (editor-side)
- Use `backingDictionary.Clear()` instead of `this.Clear` to avoid invoking `OnContentsChanged`
- Should now be safe to assign "current" items via the Inspector

## `ItemEditor`
- Fix GUI error when opening the `ItemEditor`