### PR TITLE
Clean up unequip changes

### DIFF
--- a/Assets/Prefabs/Inventory/InventoryCanvas.prefab
+++ b/Assets/Prefabs/Inventory/InventoryCanvas.prefab
@@ -1560,6 +1560,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   inventory: {fileID: 11400000, guid: 33d86f39d6e952b469a935e1a473c3dd, type: 2}
+  unequipFailSound: {fileID: 8300000, guid: 99a7404bb65be254395cd520b0ecb3f1, type: 3}
   inventoryPanel: {fileID: 5703648155880917274}
   descriptionText: {fileID: 5703648156331186497}
   closeButton: {fileID: 5703648156353208359}

--- a/Assets/ScriptableObjects/PlayerStuff/PlayerInventory.asset
+++ b/Assets/ScriptableObjects/PlayerStuff/PlayerInventory.asset
@@ -53,4 +53,3 @@ MonoBehaviour:
   totalCritChance: 105
   totalMinSpellDamage: 8
   totalMaxSpellDamage: 16
-  noInventorySpace: {fileID: 8300000, guid: 99a7404bb65be254395cd520b0ecb3f1, type: 3}

--- a/Assets/Scripts/Menus/Inventory/InventoryManager.cs
+++ b/Assets/Scripts/Menus/Inventory/InventoryManager.cs
@@ -23,6 +23,9 @@ public class InventoryManager : MonoBehaviour
 
     private InventoryDisplay inventoryDisplay;
 
+    private void OnEnable() => inventory.OnNoSpaceOrNothing += SetDescriptionToFullOrNothing;
+    private void OnDisable() => inventory.OnNoSpaceOrNothing -= SetDescriptionToFullOrNothing;
+
     private void Awake()
     {
         inventoryDisplay = GetComponentInChildren<InventoryDisplay>(true);
@@ -32,25 +35,15 @@ public class InventoryManager : MonoBehaviour
         inventoryDisplay.SubscribeToEquipmentSlotUsed(Unequip);
     }
 
-    private void OnEnable()
-    {
-        inventory.OnNoSpaceOrNothing += SetDescriptionToFullOrNothing;
-    }
-
-    private void OnDisable()
-    {
-        inventory.OnNoSpaceOrNothing -= SetDescriptionToFullOrNothing;
-    }
-
     private void SetDescriptionToFullOrNothing(Item item)
     {
-        if(item == null)
+        if (item == null)
         {
-            descriptionText.text = "Can't take of nothing...";
+            descriptionText.text = "Can't take off nothing...";
         }
         else
         {
-            descriptionText.text = "Not enaugh space to take " + item + " off...";
+            descriptionText.text = $"Not enough space to unequip {item}...";
         }
     }
 

--- a/Assets/Scripts/Menus/Inventory/InventoryManager.cs
+++ b/Assets/Scripts/Menus/Inventory/InventoryManager.cs
@@ -5,6 +5,7 @@ using UnityEngine.EventSystems;
 public class InventoryManager : MonoBehaviour
 {
     [SerializeField] private Inventory inventory = default;
+    [SerializeField] private AudioClip unequipFailSound = default;
     [Header("Components")]
     [SerializeField] private GameObject inventoryPanel = default;
     [SerializeField] private TextMeshProUGUI descriptionText = default;
@@ -23,8 +24,8 @@ public class InventoryManager : MonoBehaviour
 
     private InventoryDisplay inventoryDisplay;
 
-    private void OnEnable() => inventory.OnFailToUnequip += SetDescriptionFailedUnequip;
-    private void OnDisable() => inventory.OnFailToUnequip -= SetDescriptionFailedUnequip;
+    private void OnEnable() => inventory.OnFailToUnequip += OnFailedUnequip;
+    private void OnDisable() => inventory.OnFailToUnequip -= OnFailedUnequip;
 
     private void Awake()
     {
@@ -114,8 +115,9 @@ public class InventoryManager : MonoBehaviour
 
     private void Unequip(Item itemToUnequip) => inventory.Unequip(itemToUnequip as EquippableItem);
 
-    private void SetDescriptionFailedUnequip(Item triedItem)
+    private void OnFailedUnequip(Item triedItem)
     {
+        SoundManager.RequestSound(unequipFailSound);
         if (triedItem == null)
         {
             descriptionText.text = "Can't take off nothing...";

--- a/Assets/Scripts/Menus/Inventory/InventoryManager.cs
+++ b/Assets/Scripts/Menus/Inventory/InventoryManager.cs
@@ -124,7 +124,7 @@ public class InventoryManager : MonoBehaviour
         }
         else
         {
-            descriptionText.text = $"Not enough space to unequip {triedItem}...";
+            descriptionText.text = $"Not enough space to unequip {triedItem.name}...";
         }
     }
 

--- a/Assets/Scripts/Menus/Inventory/InventoryManager.cs
+++ b/Assets/Scripts/Menus/Inventory/InventoryManager.cs
@@ -23,8 +23,8 @@ public class InventoryManager : MonoBehaviour
 
     private InventoryDisplay inventoryDisplay;
 
-    private void OnEnable() => inventory.OnNoSpaceOrNothing += SetDescriptionToFullOrNothing;
-    private void OnDisable() => inventory.OnNoSpaceOrNothing -= SetDescriptionToFullOrNothing;
+    private void OnEnable() => inventory.OnFailToUnequip += SetDescriptionFailedUnequip;
+    private void OnDisable() => inventory.OnFailToUnequip -= SetDescriptionFailedUnequip;
 
     private void Awake()
     {
@@ -33,18 +33,6 @@ public class InventoryManager : MonoBehaviour
         inventoryDisplay.OnSlotUsed = OnItemUsed;
         inventoryDisplay.SubscribeToEquipmentSlotSelected(SetUpItemDescription);
         inventoryDisplay.SubscribeToEquipmentSlotUsed(Unequip);
-    }
-
-    private void SetDescriptionToFullOrNothing(Item item)
-    {
-        if (item == null)
-        {
-            descriptionText.text = "Can't take off nothing...";
-        }
-        else
-        {
-            descriptionText.text = $"Not enough space to unequip {item}...";
-        }
     }
 
     public void ClosePanel()
@@ -125,6 +113,18 @@ public class InventoryManager : MonoBehaviour
     }
 
     private void Unequip(Item itemToUnequip) => inventory.Unequip(itemToUnequip as EquippableItem);
+
+    private void SetDescriptionFailedUnequip(Item triedItem)
+    {
+        if (triedItem == null)
+        {
+            descriptionText.text = "Can't take off nothing...";
+        }
+        else
+        {
+            descriptionText.text = $"Not enough space to unequip {triedItem}...";
+        }
+    }
 
     private void UpdateStatDisplays()
     {

--- a/Assets/Scripts/ScriptableObjects/Inventory/Inventory.cs
+++ b/Assets/Scripts/ScriptableObjects/Inventory/Inventory.cs
@@ -114,14 +114,14 @@ public class Inventory : ScriptableObject
                 break;
             case InventoryRing ring:
                 Swap(ref currentRing, ring);
-                 break;
+                break;
 
             case InventorySpellbook spellbook:
-                if(!currentSpellbook)
+                if (!currentSpellbook)
                 {
                     Swap(ref currentSpellbook, spellbook);
                 }
-                else if(!currentSpellbookTwo)
+                else if (!currentSpellbookTwo)
                 {
                     Swap(ref currentSpellbookTwo, spellbook);
                 }
@@ -186,100 +186,100 @@ public class Inventory : ScriptableObject
 
     public void Unequip(EquippableItem item)
     {
-        if(item != null && items.HasCapacity(item))
-        { 
-        switch (item)
+        if (item != null && items.HasCapacity(item))
         {
-            default:
-                // Exit the function early if item is not equippable.
-                return;
-            case InventoryWeapon weapon:
-                Swap(ref currentWeapon, null);
-                break;
-            case InventoryArmor armor:
-                Swap(ref currentArmor, null);
-                break;
-            case InventoryHelmet helmet:
-                Swap(ref currentHelmet, null);
-                break;
-            case InventoryGlove gloves:
-                Swap(ref currentGloves, null);
-                break;
-            case InventoryLegs legs:
-                Swap(ref currentLegs, null);
-                break;
-            case InventoryShield shield:
-                Swap(ref currentShield, null);
-                break;
-            case InventoryRing ring:
-                Swap(ref currentRing, null);
-                break;
+            switch (item)
+            {
+                default:
+                    // Exit the function early if item is not equippable.
+                    return;
+                case InventoryWeapon weapon:
+                    Swap(ref currentWeapon, null);
+                    break;
+                case InventoryArmor armor:
+                    Swap(ref currentArmor, null);
+                    break;
+                case InventoryHelmet helmet:
+                    Swap(ref currentHelmet, null);
+                    break;
+                case InventoryGlove gloves:
+                    Swap(ref currentGloves, null);
+                    break;
+                case InventoryLegs legs:
+                    Swap(ref currentLegs, null);
+                    break;
+                case InventoryShield shield:
+                    Swap(ref currentShield, null);
+                    break;
+                case InventoryRing ring:
+                    Swap(ref currentRing, null);
+                    break;
 
-            case InventorySpellbook spellbook:
-                if (currentSpellbook == spellbook)
-                {
-                    Swap(ref currentSpellbook, null);
-                }
-                else if (currentSpellbookTwo == spellbook)
-                {
-                    Swap(ref currentSpellbookTwo, null);
-                }
-                else
-                {
-                    Swap(ref currentSpellbookThree, null);
-                }
-                break;
+                case InventorySpellbook spellbook:
+                    if (currentSpellbook == spellbook)
+                    {
+                        Swap(ref currentSpellbook, null);
+                    }
+                    else if (currentSpellbookTwo == spellbook)
+                    {
+                        Swap(ref currentSpellbookTwo, null);
+                    }
+                    else
+                    {
+                        Swap(ref currentSpellbookThree, null);
+                    }
+                    break;
 
-            case InventoryAmulet amulet:
-                Swap(ref currentAmulet, null);
-                break;
-            case InventoryBoots boots:
-                Swap(ref currentBoots, null);
-                break;
-            case InventoryLamp lamp:
-                Swap(ref currentLamp, null);
-                break;
-            case InventoryCloak cloak:
-                Swap(ref currentCloak, null);
-                break;
-            case InventoryBelt belt:
-                Swap(ref currentBelt, null);
-                break;
-            case InventoryShoulder shoulder:
-                Swap(ref currentShoulder, null);
-                break;
-            case InventorySeal seal:
-                Swap(ref currentSeal, null);
-                break;
-            case QuestSeed seed:
-                Swap(ref currentSeed, null);
-                break;
-            case QuestRune rune:
-                Swap(ref currentRune, null);
-                break;
-            case QuestGem gem:
-                Swap(ref currentGem, null);
-                break;
-            case QuestPearl pearl:
-                Swap(ref currentPearl, null);
-                break;
-            case QuestArtifact artifact:
-                Swap(ref currentArtifact, null);
-                break;
-            case QuestCrown crown:
-                Swap(ref currentCrown, null);
-                break;
-            case QuestScepter scepter:
-                Swap(ref currentScepter, null);
-                break;
-            case QuestDragonEgg dragonEgg:
-                Swap(ref currentDragonEgg, null);
-                break;
-        }
+                case InventoryAmulet amulet:
+                    Swap(ref currentAmulet, null);
+                    break;
+                case InventoryBoots boots:
+                    Swap(ref currentBoots, null);
+                    break;
+                case InventoryLamp lamp:
+                    Swap(ref currentLamp, null);
+                    break;
+                case InventoryCloak cloak:
+                    Swap(ref currentCloak, null);
+                    break;
+                case InventoryBelt belt:
+                    Swap(ref currentBelt, null);
+                    break;
+                case InventoryShoulder shoulder:
+                    Swap(ref currentShoulder, null);
+                    break;
+                case InventorySeal seal:
+                    Swap(ref currentSeal, null);
+                    break;
+                case QuestSeed seed:
+                    Swap(ref currentSeed, null);
+                    break;
+                case QuestRune rune:
+                    Swap(ref currentRune, null);
+                    break;
+                case QuestGem gem:
+                    Swap(ref currentGem, null);
+                    break;
+                case QuestPearl pearl:
+                    Swap(ref currentPearl, null);
+                    break;
+                case QuestArtifact artifact:
+                    Swap(ref currentArtifact, null);
+                    break;
+                case QuestCrown crown:
+                    Swap(ref currentCrown, null);
+                    break;
+                case QuestScepter scepter:
+                    Swap(ref currentScepter, null);
+                    break;
+                case QuestDragonEgg dragonEgg:
+                    Swap(ref currentDragonEgg, null);
+                    break;
+            }
 
-        CalcDefense();
-        CalcCritChance();
-        CalcSpellDamage();
+            CalcDefense();
+            CalcCritChance();
+            CalcSpellDamage();
         }
         else
         {
@@ -393,7 +393,7 @@ public class Inventory : ScriptableObject
 
         if (currentSpellbook || currentSpellbookTwo || currentSpellbookThree)
         {
-            if(currentSpellbook)
+            if (currentSpellbook)
             {
                 totalMinSpellDamage += currentSpellbook.minSpellDamage;
                 totalMaxSpellDamage += currentSpellbook.maxSpellDamage;

--- a/Assets/Scripts/ScriptableObjects/Inventory/Inventory.cs
+++ b/Assets/Scripts/ScriptableObjects/Inventory/Inventory.cs
@@ -57,9 +57,6 @@ public class Inventory : ScriptableObject
     public int totalMinSpellDamage;
     public int totalMaxSpellDamage;
 
-    [Header("Sounds")]
-    [SerializeField] private AudioClip noInventorySpace = default;
-
 #if UNITY_EDITOR
     // Needed in order to allow changes to the Inventory in the editor to be saved.
 
@@ -284,7 +281,6 @@ public class Inventory : ScriptableObject
         else
         {
             OnFailToUnequip?.Invoke(item);
-            SoundManager.RequestSound(noInventorySpace);
         }
     }
 

--- a/Assets/Scripts/ScriptableObjects/Inventory/Inventory.cs
+++ b/Assets/Scripts/ScriptableObjects/Inventory/Inventory.cs
@@ -7,7 +7,7 @@ public class Inventory : ScriptableObject
     public Schwer.ItemSystem.Inventory items = new Schwer.ItemSystem.Inventory();
 
     public event Action OnEquipmentChanged;
-    public event Action<Item> OnNoSpaceOrNothing;
+    public event Action<Item> OnFailToUnequip;
 
     public event Action OnCoinCountChanged;
     [SerializeField] private int _coins;
@@ -283,7 +283,7 @@ public class Inventory : ScriptableObject
         }
         else
         {
-            OnNoSpaceOrNothing?.Invoke(item);
+            OnFailToUnequip?.Invoke(item);
             SoundManager.RequestSound(noInventorySpace);
         }
     }


### PR DESCRIPTION
Clean up after commit 43fc84c2:
- Rename `OnNoSpaceOrNothing` to `OnFailToUnequip` in `Inventory`
- Rename `SetDescriptionToFullOrNothing` to `OnFailedUnequip` in `InventoryManager`
    - Rename `item` parameter to `triedItem`
    - Change description to be set to `$"Not enough space to unequip {triedItem.name}..."`  instead of `"Not enaugh space to take " + item + " off..."`
- Move sound responsibility to `InventoryManager`