### PR TITLE
Fix menu opening

### DIFF
--- a/Assets/Scripts/Characters/Player/PlayerMovement.cs
+++ b/Assets/Scripts/Characters/Player/PlayerMovement.cs
@@ -134,6 +134,7 @@ public class PlayerMovement : Character, ICanMove
     {
         if (Time.timeScale > 0)
         {
+            HandleMenus();
             HandleInput();
             HandleState();
             // Debug.Log($"{name}: {currentState}");
@@ -154,6 +155,14 @@ public class PlayerMovement : Character, ICanMove
         {
             rigidbody.velocity = Vector2.zero;
         }
+    }
+
+    private void HandleMenus()
+    {
+        input.openInv = Input.GetButtonDown("Inventory");
+        input.openLoad = Input.GetButtonDown("Pause");
+
+        if (inputLoad) PauseManager.RequestPauseMenu();
     }
 
     private void HandleInput()
@@ -179,9 +188,6 @@ public class PlayerMovement : Character, ICanMove
         input.spellCast1 = Input.GetButton("SpellCast");
         input.spellCast2 = Input.GetButton("SpellCast2");
         input.spellCast3 = Input.GetButton("SpellCast3");
-
-        input.openInv = Input.GetButtonDown("Inventory");
-        input.openLoad = Input.GetButtonDown("Pause");
     }
 
     private void HandleState()

--- a/Assets/Scripts/Characters/Player/PlayerMovement.cs
+++ b/Assets/Scripts/Characters/Player/PlayerMovement.cs
@@ -162,6 +162,7 @@ public class PlayerMovement : Character, ICanMove
         input.openInv = Input.GetButtonDown("Inventory");
         input.openLoad = Input.GetButtonDown("Pause");
 
+        if (inputInv) InventoryManager.RequestInventoryMenu();
         if (inputLoad) PauseManager.RequestPauseMenu();
     }
 

--- a/Assets/Scripts/Menus/Inventory/InventoryManager.cs
+++ b/Assets/Scripts/Menus/Inventory/InventoryManager.cs
@@ -1,9 +1,13 @@
 ﻿using UnityEngine;
 using TMPro;
 using UnityEngine.EventSystems;
+using System;
 
 public class InventoryManager : MonoBehaviour
 {
+    private static event Action OnInventoryMenuRequested;
+    public static void RequestInventoryMenu() => OnInventoryMenuRequested?.Invoke();
+
     [SerializeField] private Inventory inventory = default;
 
     [Header("References")]
@@ -37,8 +41,15 @@ public class InventoryManager : MonoBehaviour
 
     private InventoryDisplay inventoryDisplay;
 
-    private void OnEnable() => inventory.OnFailToUnequip += OnFailedUnequip;
-    private void OnDisable() => inventory.OnFailToUnequip -= OnFailedUnequip;
+    private void OnEnable() {
+        OnInventoryMenuRequested += HandleMenuRequest;
+        inventory.OnFailToUnequip += OnFailedUnequip;
+    }
+
+    private void OnDisable() {
+        OnInventoryMenuRequested -= HandleMenuRequest;
+        inventory.OnFailToUnequip -= OnFailedUnequip;
+    }
 
     private void Start()
     {
@@ -76,9 +87,9 @@ public class InventoryManager : MonoBehaviour
         }
     }
 
-    private void Update()
+    private void HandleMenuRequest()
     {
-        if (player.inputInv && CanvasManager.Instance.IsFreeOrActive(inventoryPanel.gameObject))
+        if (CanvasManager.Instance.IsFreeOrActive(inventoryPanel.gameObject))
         {
             Debug.Log("INV OPEN");
             if (inventoryPanel.activeInHierarchy)

--- a/Assets/Scripts/Menus/PauseManager.cs
+++ b/Assets/Scripts/Menus/PauseManager.cs
@@ -1,16 +1,22 @@
-﻿using UnityEngine;
+﻿using System;
+using UnityEngine;
 using UnityEngine.EventSystems;
 using UnityEngine.SceneManagement;
 
 public class PauseManager : MonoBehaviour
 {
+    private static event Action OnPauseMenuRequested;
+    public static void RequestPauseMenu() => OnPauseMenuRequested?.Invoke();
+
     public GameObject pausePanel;
     public GameObject loadPanel;
     public GameObject firstButtonPause;
     [SerializeField] private BoolValue torchAndBrazierParticlesOn;
 
+    private void OnEnable() => OnPauseMenuRequested += OpenMenu;
+    private void OnDisable() => OnPauseMenuRequested -= OpenMenu;
 
-    private void Update()
+    private void OpenMenu()
     {
         if (CanvasManager.Instance.IsFreeOrActive(pausePanel))
         {

--- a/Assets/Scripts/Menus/PauseManager.cs
+++ b/Assets/Scripts/Menus/PauseManager.cs
@@ -8,32 +8,22 @@ public class PauseManager : MonoBehaviour
     public GameObject loadPanel;
     public GameObject firstButtonPause;
     [SerializeField] private BoolValue torchAndBrazierParticlesOn;
-    [SerializeField] private PlayerMovement player;
 
-
-    private void Start()
-    {
-        player = GameObject.FindObjectOfType<PlayerMovement>();
-    }
 
     private void Update()
     {
-        if(player)
+        if (CanvasManager.Instance.IsFreeOrActive(pausePanel))
         {
-            if (player.inputLoad && CanvasManager.Instance.IsFreeOrActive(pausePanel))
+            loadPanel.SetActive(false);
+            ChangePause();
+            if (firstButtonPause)
             {
-                loadPanel.SetActive(false);
-                ChangePause();
-                if (firstButtonPause)
-                {
-                    EventSystem.current.SetSelectedGameObject(null);
-                    EventSystem.current.SetSelectedGameObject(firstButtonPause);
-                }
+                EventSystem.current.SetSelectedGameObject(null);
+                EventSystem.current.SetSelectedGameObject(firstButtonPause);
             }
         }
     }
 
-   
     private void ChangePause()
     {
         var isPaused = !pausePanel.activeSelf;

--- a/Assets/Scripts/Menus/PauseManager.cs
+++ b/Assets/Scripts/Menus/PauseManager.cs
@@ -10,7 +10,6 @@ public class PauseManager : MonoBehaviour
     [SerializeField] private BoolValue torchAndBrazierParticlesOn;
     [SerializeField] private PlayerMovement player;
 
-    private bool isPaused = false;
 
     private void Start()
     {
@@ -37,7 +36,7 @@ public class PauseManager : MonoBehaviour
    
     private void ChangePause()
     {
-        isPaused = !isPaused;
+        var isPaused = !pausePanel.activeSelf;
         Time.timeScale = isPaused ? 0 : 1;
         pausePanel.SetActive(isPaused);
         if (!isPaused)
@@ -51,7 +50,7 @@ public class PauseManager : MonoBehaviour
         SceneManager.LoadScene("StartMenu");
         Time.timeScale = 1f;
     }
-         
+
     public void Save() => SaveManager.Instance.Save("saveSlot1");
 
     public void Reset() => SaveManager.Instance.LoadNew();


### PR DESCRIPTION
## Why
Changes made to how the pause menu and inventory manager open broke keyboard/gamepad input opening (i.e. using ui buttons work as expected but using keyboard/gamepad input seemingly triggers the logic twice across two frames, turning the menu on then off). The cause of the bug is still unknown.

## Fix
Use an event-based method when the player inputs the appropriate button instead of using `Update` in each manager to check for player input.