### PR TITLE
Fix player appearance in Editor

### DIFF
--- a/Assets/Scripts/Menus/CharacterCreation/CharacterCreation.cs
+++ b/Assets/Scripts/Menus/CharacterCreation/CharacterCreation.cs
@@ -153,7 +153,7 @@ public class CharacterCreation : MonoBehaviour
 
     public void SaveAppearance()
     {
-        characterAppearance.index = texturesCounter;
+        characterAppearance.skinIndex = texturesCounter;
 
         characterAppearance.armorStyle = activeTextures.armorSkins[armorCounter];
         characterAppearance.eyeColor = activeTextures.eyeSkins[eyeCounter];

--- a/Assets/Scripts/ScriptableObjects/CharacterAppearance.cs
+++ b/Assets/Scripts/ScriptableObjects/CharacterAppearance.cs
@@ -24,11 +24,9 @@ public class CharacterAppearance : ScriptableObject
     public string armorFolderPath { get; set; }
     public string eyeFolderPath { get; set; }
 
-#if UNITY_EDITOR
+#if UNITY_EDITOR    // Reason: paths are normally set when save data is loaded, but this is skipped in editor
     private void OnValidate() => OnEnable();
     private void OnEnable() {
-        // if (!Application.isPlaying) return;
-
         var path = "Assets/Resources/";
         bodyFolderPath = UnityEditor.AssetDatabase.GetAssetPath(bodyStyle).Replace(path, "");
         bodyFolderPath = bodyFolderPath.Remove(bodyFolderPath.LastIndexOf("/") + 1);

--- a/Assets/Scripts/ScriptableObjects/CharacterAppearance.cs
+++ b/Assets/Scripts/ScriptableObjects/CharacterAppearance.cs
@@ -11,8 +11,7 @@ public class CharacterAppearance : ScriptableObject
     public string playerName;
 
     // Runtime only — not serialized (indexes and paths)
-    public int index { get; set; }  //! Currently used for differentiating between male and female skin textures, should rename
-
+    public int skinIndex { get; set; }
     public int bodyIndex { get; set; }
     public int hairIndex { get; set; }
     public int armorIndex { get; set; }
@@ -43,7 +42,7 @@ public class CharacterAppearance : ScriptableObject
     public void Deserialize(CharacterAppearanceSerializable cas, SkinTexturesDatabase[] skinTextures)
     {
         playerName = cas.playerName;
-        index = cas.index;
+        skinIndex = cas.skinIndex;
 
         bodyIndex = cas.bodyIndex;
         hairIndex = cas.hairIndex;
@@ -51,7 +50,7 @@ public class CharacterAppearance : ScriptableObject
         armorIndex = cas.armorIndex;
         eyeIndex = cas.eyeIndex;
 
-        var activeTextures = skinTextures[index];
+        var activeTextures = skinTextures[skinIndex];
 
         bodyStyle = activeTextures.bodySkins[bodyIndex];
         hairStyle = activeTextures.hairStyles[hairIndex];
@@ -69,7 +68,7 @@ public class CharacterAppearance : ScriptableObject
     {
         [ES3Serializable] public string playerName { get; private set; }
 
-        [ES3Serializable] public int index { get; private set; }
+        [ES3Serializable] public int skinIndex { get; private set; }
 
         [ES3Serializable] public int bodyIndex { get; private set; }
         [ES3Serializable] public int hairIndex { get; private set; }
@@ -81,7 +80,7 @@ public class CharacterAppearance : ScriptableObject
         {
             playerName = ca.playerName;
 
-            index = ca.index;
+            skinIndex = ca.skinIndex;
 
             bodyIndex = ca.bodyIndex;
             hairIndex = ca.hairIndex;

--- a/Assets/Scripts/ScriptableObjects/CharacterAppearance.cs
+++ b/Assets/Scripts/ScriptableObjects/CharacterAppearance.cs
@@ -27,7 +27,7 @@ public class CharacterAppearance : ScriptableObject
 #if UNITY_EDITOR
     private void OnValidate() => OnEnable();
     private void OnEnable() {
-        if (!Application.isPlaying) return;
+        // if (!Application.isPlaying) return;
 
         var path = "Assets/Resources/";
         bodyFolderPath = UnityEditor.AssetDatabase.GetAssetPath(bodyStyle).Replace(path, "");

--- a/Assets/Scripts/ScriptableObjects/CharacterAppearance.cs
+++ b/Assets/Scripts/ScriptableObjects/CharacterAppearance.cs
@@ -7,18 +7,17 @@ public class CharacterAppearance : ScriptableObject
     public Texture2D hairStyle;
     public Texture2D armorStyle;
     public Texture2D eyeColor;
+    public Color hairColor;
+    public string playerName;
 
-    public string playerName;   // Should probably make into property with private backing field exposed to Inspector
-
-    public int index { get; set; }
+    // Runtime only — not serialized (indexes and paths)
+    public int index { get; set; }  //! Currently used for differentiating between male and female skin textures, should rename
 
     public int bodyIndex { get; set; }
     public int hairIndex { get; set; }
-    public Color hairColor;     // Should probably make into property with private backing field exposed to Inspector
     public int armorIndex { get; set; }
     public int eyeIndex { get; set; }
 
-    // Runtime only
     public string bodyFolderPath { get; set; }
     public string hairFolderPath { get; set; }
     public string armorFolderPath { get; set; }


### PR DESCRIPTION
Fix error with fd1fcef80 — `OnEnable` for `ScriptableObject`s occur when the object is loaded, which can occur when selected in the Inspector or when used in a scene (i.e. can occur in either Edit mode and Play mode, so can't restrict it to edit mode only).

Also rearranged `CharacterAppearance` variables.