### PR TITLE
Fix dialogue loop

### DIFF
--- a/Assets/Scripts/Dialogue/DialogueManager.cs
+++ b/Assets/Scripts/Dialogue/DialogueManager.cs
@@ -35,9 +35,11 @@ public class DialogueManager : MonoBehaviour
 
     private void StartDialogue(Dialogue dialogue)
     {
-        dialoguePanel.SetActive(true);
         if (CanvasManager.Instance.IsFreeOrActive(dialoguePanel))
         {
+            dialoguePanel.SetActive(true);
+            animator.SetBool("isActive", true);
+
             if (nextButton)
             {
                 EventSystem.current.SetSelectedGameObject(null);
@@ -76,7 +78,6 @@ public class DialogueManager : MonoBehaviour
 
     private IEnumerator TypeSentence(string sentence)
     {
-        animator.SetBool("isActive", true);
         dialogueText.text = "";
         foreach (char letter in sentence.ToCharArray())
         {

--- a/Assets/Scripts/Dialogue/DialogueTrigger.cs
+++ b/Assets/Scripts/Dialogue/DialogueTrigger.cs
@@ -7,7 +7,7 @@ public class DialogueTrigger : ComponentTrigger<PlayerMovement>
     [SerializeField] private Dialogue dialogue = default;
     private PlayerMovement player;
 
-    private void Update()
+    private void LateUpdate()
     {
         if (player != null && player.inputInteract && Time.timeScale > 0)
         {

--- a/Assets/Scripts/Objects/Doors/ItemDoor.cs
+++ b/Assets/Scripts/Objects/Doors/ItemDoor.cs
@@ -26,7 +26,7 @@ public class ItemDoor : Interactable
     }
     //########################## Doormemory END ##################################
 
-    private void Update()
+    private void LateUpdate()
     {
         if (playerInRange && player.inputInteract && Time.timeScale > 0)
         {


### PR DESCRIPTION
Ambiguous `Update` order meant that `DialogueTrigger` and `ItemDoor` could sometimes read player input before `inputInteract` could be updated to be `false`, resulting in the player being stuck in a dialogue loop. Use `LateUpdate` to avoid this ambiguity.

The animation for the appearance of the dialogue panel may need to updated, as currently it flashes on screen the first time dialogue is triggered in a scene before sliding in as expected.