### PR TITLE
Implement cutscene dialogue

### DIFF
--- a/Assets/Scenes/Cutscenes/Mavens_Inn_Cutscene.unity
+++ b/Assets/Scenes/Cutscenes/Mavens_Inn_Cutscene.unity
@@ -3077,6 +3077,8 @@ PlayableDirector:
     value: {fileID: 766396329}
   - key: {fileID: -1932929307147882573, guid: 605efd19a3f8a454da62981cc30b01ba, type: 2}
     value: {fileID: 766396329}
+  - key: {fileID: 3585430965542914627, guid: 605efd19a3f8a454da62981cc30b01ba, type: 2}
+    value: {fileID: 1733759622}
   m_ExposedReferences:
     m_References: []
 --- !u!4 &1733759624
@@ -3102,28 +3104,9 @@ MonoBehaviour:
   m_GameObject: {fileID: 1733759622}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: e52de21a22b6dd44c9cc19f810c65059, type: 3}
+  m_Script: {fileID: 11500000, guid: 0dd35b80fca3424498096df7ecf4d942, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  m_Events:
-    m_Signals:
-    - {fileID: 11400000, guid: deaf73fc9e871ec41a460c31e628b835, type: 2}
-    m_Events:
-    - m_PersistentCalls:
-        m_Calls:
-        - m_Target: {fileID: 2108386366}
-          m_TargetAssemblyTypeName: DialogueManager, Assembly-CSharp
-          m_MethodName: StartDialogue
-          m_Mode: 2
-          m_Arguments:
-            m_ObjectArgument: {fileID: 11400000, guid: 00f1f9bbe709d87429ef5c567112ba4c,
-              type: 2}
-            m_ObjectArgumentAssemblyTypeName: DialogueSO, Assembly-CSharp
-            m_IntArgument: 0
-            m_FloatArgument: 0
-            m_StringArgument: 
-            m_BoolArgument: 0
-          m_CallState: 2
 --- !u!1001 &1748063453
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -3586,18 +3569,6 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 5276e0f7c123b7b4c871bc76458cff0a, type: 3}
---- !u!114 &2108386366 stripped
-MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 1395598622741407489, guid: 5276e0f7c123b7b4c871bc76458cff0a,
-    type: 3}
-  m_PrefabInstance: {fileID: 2108386365}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: c5ef95982a21ed44eae1d7a223c16625, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!1001 &338648976605178803
 PrefabInstance:
   m_ObjectHideFlags: 0

--- a/Assets/Scenes/Cutscenes/Mavens_Inn_Cutscene.unity
+++ b/Assets/Scenes/Cutscenes/Mavens_Inn_Cutscene.unity
@@ -3048,6 +3048,7 @@ GameObject:
   m_Component:
   - component: {fileID: 1733759624}
   - component: {fileID: 1733759623}
+  - component: {fileID: 1733759625}
   m_Layer: 0
   m_Name: TimeLineManager
   m_TagString: Untagged
@@ -3092,6 +3093,37 @@ Transform:
   m_Father: {fileID: 0}
   m_RootOrder: 10
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &1733759625
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1733759622}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: e52de21a22b6dd44c9cc19f810c65059, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Events:
+    m_Signals:
+    - {fileID: 11400000, guid: deaf73fc9e871ec41a460c31e628b835, type: 2}
+    m_Events:
+    - m_PersistentCalls:
+        m_Calls:
+        - m_Target: {fileID: 2108386366}
+          m_TargetAssemblyTypeName: DialogueManager, Assembly-CSharp
+          m_MethodName: StartDialogue
+          m_Mode: 2
+          m_Arguments:
+            m_ObjectArgument: {fileID: 11400000, guid: 00f1f9bbe709d87429ef5c567112ba4c,
+              type: 2}
+            m_ObjectArgumentAssemblyTypeName: DialogueSO, Assembly-CSharp
+            m_IntArgument: 0
+            m_FloatArgument: 0
+            m_StringArgument: 
+            m_BoolArgument: 0
+          m_CallState: 2
 --- !u!1001 &1748063453
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -3554,6 +3586,18 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 5276e0f7c123b7b4c871bc76458cff0a, type: 3}
+--- !u!114 &2108386366 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 1395598622741407489, guid: 5276e0f7c123b7b4c871bc76458cff0a,
+    type: 3}
+  m_PrefabInstance: {fileID: 2108386365}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: c5ef95982a21ed44eae1d7a223c16625, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1001 &338648976605178803
 PrefabInstance:
   m_ObjectHideFlags: 0

--- a/Assets/ScriptableObjects/Dialogue.meta
+++ b/Assets/ScriptableObjects/Dialogue.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 50fedc45018a04c44af77f234ab4cd33
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/ScriptableObjects/Dialogue/OpeningCutsceneDialogueTest.asset
+++ b/Assets/ScriptableObjects/Dialogue/OpeningCutsceneDialogueTest.asset
@@ -1,0 +1,20 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4663fe09e088f75469e6346b621f3d23, type: 3}
+  m_Name: OpeningCutsceneDialogueTest
+  m_EditorClassIdentifier: 
+  value:
+    npcName: Opening Test
+    sentences:
+    - "Tell you, you're the greatest\r"
+    - "But once you turn, they hate us\r"
+    - Oh, the misery

--- a/Assets/ScriptableObjects/Dialogue/OpeningCutsceneDialogueTest.asset.meta
+++ b/Assets/ScriptableObjects/Dialogue/OpeningCutsceneDialogueTest.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 00f1f9bbe709d87429ef5c567112ba4c
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Dialogue/DialogueManager.cs
+++ b/Assets/Scripts/Dialogue/DialogueManager.cs
@@ -33,6 +33,8 @@ public class DialogueManager : MonoBehaviour
         OnEndDialogue -= EndDialogue;
     }
 
+    public void StartDialogue(DialogueSO dialogue) => StartDialogue(dialogue.value);
+
     private void StartDialogue(Dialogue dialogue)
     {
         if (CanvasManager.Instance.IsFreeOrActive(dialoguePanel))

--- a/Assets/Scripts/Dialogue/DialogueManager.cs
+++ b/Assets/Scripts/Dialogue/DialogueManager.cs
@@ -33,8 +33,6 @@ public class DialogueManager : MonoBehaviour
         OnEndDialogue -= EndDialogue;
     }
 
-    public void StartDialogue(DialogueSO dialogue) => StartDialogue(dialogue.value);
-
     private void StartDialogue(Dialogue dialogue)
     {
         if (CanvasManager.Instance.IsFreeOrActive(dialoguePanel))

--- a/Assets/Scripts/Dialogue/DialogueSO.cs
+++ b/Assets/Scripts/Dialogue/DialogueSO.cs
@@ -1,0 +1,7 @@
+using UnityEngine;
+
+[CreateAssetMenu(menuName = "Scriptable Object/Dialogue")]
+public class DialogueSO : ScriptableObject
+{
+    public Dialogue value;
+}

--- a/Assets/Scripts/Dialogue/DialogueSO.cs.meta
+++ b/Assets/Scripts/Dialogue/DialogueSO.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 4663fe09e088f75469e6346b621f3d23
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Dialogue/Timeline.meta
+++ b/Assets/Scripts/Dialogue/Timeline.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: ebf9f45eea9278f4fb8f523b65d6beca
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Dialogue/Timeline/DialogueSignalEmitter.cs
+++ b/Assets/Scripts/Dialogue/Timeline/DialogueSignalEmitter.cs
@@ -1,0 +1,8 @@
+using UnityEngine;
+using UnityEngine.Timeline;
+
+public class DialogueSignalEmitter : SignalEmitter
+{
+    [SerializeField] private DialogueSO _parameter;
+    public Dialogue parameter => _parameter.value;
+}

--- a/Assets/Scripts/Dialogue/Timeline/DialogueSignalEmitter.cs.meta
+++ b/Assets/Scripts/Dialogue/Timeline/DialogueSignalEmitter.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: aa53eb722cc11124fa1677fd77224d8c
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Dialogue/Timeline/DialogueSignalReceiver.cs
+++ b/Assets/Scripts/Dialogue/Timeline/DialogueSignalReceiver.cs
@@ -1,0 +1,14 @@
+using UnityEngine;
+using UnityEngine.Playables;
+
+public class DialogueSignalReceiver : MonoBehaviour, INotificationReceiver
+{
+    // https://gametorrahod.com/how-to-make-a-custom-signal-receiver-with-emitter-parameter/
+    public void OnNotify(Playable origin, INotification notification, object context)
+    {
+        if (notification is DialogueSignalEmitter e)
+        {
+            DialogueManager.RequestDialogue(e.parameter);
+        }
+    }
+}

--- a/Assets/Scripts/Dialogue/Timeline/DialogueSignalReceiver.cs.meta
+++ b/Assets/Scripts/Dialogue/Timeline/DialogueSignalReceiver.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 0dd35b80fca3424498096df7ecf4d942
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/TimeLine/OpeningCutscene.playable
+++ b/Assets/TimeLine/OpeningCutscene.playable
@@ -1,5 +1,21 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
+--- !u!114 &-8156145696408882329
+MonoBehaviour:
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 15c38f6fa1940124db1ab7f6fe7268d1, type: 3}
+  m_Name: Signal Emitter
+  m_EditorClassIdentifier: 
+  m_Time: 5.75
+  m_Retroactive: 0
+  m_EmitOnce: 0
+  m_Asset: {fileID: 11400000, guid: deaf73fc9e871ec41a460c31e628b835, type: 2}
 --- !u!114 &-7745909800657283134
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -553,7 +569,8 @@ MonoBehaviour:
   m_Children: []
   m_Clips: []
   m_Markers:
-    m_Objects: []
+    m_Objects:
+    - {fileID: -8156145696408882329}
 --- !u!114 &4454808801353666771
 MonoBehaviour:
   m_ObjectHideFlags: 1

--- a/Assets/TimeLine/OpeningCutscene.playable
+++ b/Assets/TimeLine/OpeningCutscene.playable
@@ -1,21 +1,5 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
---- !u!114 &-8156145696408882329
-MonoBehaviour:
-  m_ObjectHideFlags: 1
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 15c38f6fa1940124db1ab7f6fe7268d1, type: 3}
-  m_Name: Signal Emitter
-  m_EditorClassIdentifier: 
-  m_Time: 5.75
-  m_Retroactive: 0
-  m_EmitOnce: 0
-  m_Asset: {fileID: 11400000, guid: deaf73fc9e871ec41a460c31e628b835, type: 2}
 --- !u!114 &-7745909800657283134
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -57,6 +41,23 @@ MonoBehaviour:
   m_OpenClipOffsetRotation: {x: 0, y: 0, z: 0, w: 1}
   m_Rotation: {x: 0, y: 0, z: 0, w: 1}
   m_ApplyOffsets: 0
+--- !u!114 &-7533238297873421699
+MonoBehaviour:
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: aa53eb722cc11124fa1677fd77224d8c, type: 3}
+  m_Name: Dialogue Signal Emitter
+  m_EditorClassIdentifier: 
+  m_Time: 5.75
+  m_Retroactive: 0
+  m_EmitOnce: 0
+  m_Asset: {fileID: 11400000, guid: deaf73fc9e871ec41a460c31e628b835, type: 2}
+  _parameter: {fileID: 11400000, guid: 00f1f9bbe709d87429ef5c567112ba4c, type: 2}
 --- !u!114 &-6802957200508825279
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -570,7 +571,7 @@ MonoBehaviour:
   m_Clips: []
   m_Markers:
     m_Objects:
-    - {fileID: -8156145696408882329}
+    - {fileID: -7533238297873421699}
 --- !u!114 &4454808801353666771
 MonoBehaviour:
   m_ObjectHideFlags: 1

--- a/Assets/TimeLine/Signals.meta
+++ b/Assets/TimeLine/Signals.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 88a82fb350417ef4688ec29510db909d
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/TimeLine/Signals/Dialogue.signal
+++ b/Assets/TimeLine/Signals/Dialogue.signal
@@ -1,0 +1,14 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: d6fa2d92fc1b3f34da284357edf89c3b, type: 3}
+  m_Name: Dialogue
+  m_EditorClassIdentifier: 

--- a/Assets/TimeLine/Signals/Dialogue.signal.meta
+++ b/Assets/TimeLine/Signals/Dialogue.signal.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: deaf73fc9e871ec41a460c31e628b835
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Adds the ability to trigger dialogue from timeline assets

### Usage
1. Add a `DialogueSignalReceiver` component to the game object with the applicable `PlayableDirector`
2. In the Timeline window, right-click on the *Markers* section *(make show* Show markers *is toggled on)* at the desired time and choose *Add Dialogue Signal Emitter From Signal Asset*
3. Choose the existing *Dialogue* signal asset
4. Assign the desired `DialogueSO` *(or create one)*